### PR TITLE
Fix path in tests for module discovery

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,8 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from app.engine import RuleEngine
 from app.models import RuleModel
 from fastapi.testclient import TestClient


### PR DESCRIPTION
## Summary
- fix module path so `app` package is found during tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879fa384cd0832497ec94f67e2a0360